### PR TITLE
Allow remote calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### RPC server implementation to easily connect to ARK blockchain
 
 # Security Warning
-All calls should be made from the server where RPC is running at ( i.e., `localhost` or `127.0.0.1` ). The RPC server should never be publicly accessible.
+All calls should be made from the server where RPC is running at ( i.e., `localhost` or `127.0.0.1` ). The RPC server should never be publicly accessible. If you do want to access the server from a host other than localhost, start ark-rpc with the `--allow-remote` commandline switch.
 
 # How To Use It
 - install Node.JS ( https://nodejs.org/en/download/package-manager/)

--- a/server.js
+++ b/server.js
@@ -9,12 +9,16 @@ var program = require('commander');
 var server = null;
 
 function restrictToLocalhost(req, res, next){
-  if(req.getRoute().path == '/:network/broadcast' || req.connection.remoteAddress == "::1" || req.connection.remoteAddress == "127.0.0.1" || req.connection.remoteAddress == "::ffff:127.0.0.1")
-    next();
-  else res.end();
+  if(program.allowRemote) next();
+  else
+    if(req.getRoute().path == '/:network/broadcast' || req.connection.remoteAddress == "::1" || req.connection.remoteAddress == "127.0.0.1" || req.connection.remoteAddress == "::ffff:127.0.0.1")
+      next();
+    else res.end();
 }
 
 function startServer(port){
+  if (program.allowRemote) console.log('Warning! ark-rpc allows remote connections, this is potentially insecure!');
+
   server = restify.createServer().
     use(restrictToLocalhost).
     use(restify.plugins.bodyParser({mapParams: true})).
@@ -37,6 +41,7 @@ function startServer(port){
 
 program.
   option('-p, --port <port>', 'The port to start server').
+  option('--allow-remote', 'Allow connections from sources other than localhost').
   parse(process.argv);
 
 if(program.port)


### PR DESCRIPTION
As requested by @LiddleDev on gitter, this commit allows disabling the
integrated security feature of only allowing localhost to connect to the
ark-rpc server.

This behavior has to explicitly be enabled by supplying `--allow-remote`
as a commandline argument to the ark-rpc server.

The README has been changed to reflect this change.